### PR TITLE
Add support Linksys e8350

### DIFF
--- a/target/linux/ipq806x/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq806x/base-files/etc/board.d/01_leds
@@ -21,6 +21,9 @@ edgecore,ecw5410)
 	ucidef_set_led_wlan "wlan2g" "WLAN2G" "green:wlan2g" "phy1tpt"
 	ucidef_set_led_wlan "wlan5g" "WLAN5G" "green:wlan5g" "phy0tpt"
 	;;
+linksys,e8350-v1)
+	ucidef_set_led_wlan "wlan" "WLAN" "green:wifi" "phy0tpt"
+	;;
 meraki,mr52)
 	ucidef_set_led_netdev "eth0" "eth0" "green:lan1" "eth0"
 	ucidef_set_led_netdev "eth1" "eth1" "green:lan2" "eth1"

--- a/target/linux/ipq806x/base-files/etc/board.d/02_network
+++ b/target/linux/ipq806x/base-files/etc/board.d/02_network
@@ -82,6 +82,7 @@ tplink,ad7200)
 ubnt,unifi-ac-hd)
 	ucidef_set_interface_lan "eth0 eth1"
 	;;
+linksys,e8350-v1 |\
 zyxel,nbg6817)
 	hw_mac_addr=$(mtd_get_mac_ascii 0:appsblenv ethaddr)
 	ucidef_add_switch "switch0" \

--- a/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
@@ -1,7 +1,7 @@
 PART_NAME=firmware
 REQUIRE_IMAGE_METADATA=1
 
-RAMFS_COPY_BIN='fw_printenv fw_setenv'
+RAMFS_COPY_BIN='fw_printenv fw_setenv fwtool'
 RAMFS_COPY_DATA='/etc/fw_env.config /var/lock/fw_printenv.lock'
 
 platform_check_image() {
@@ -13,6 +13,7 @@ platform_do_upgrade() {
 	arris,tr4400-v2 |\
 	askey,rt4230w-rev6 |\
 	compex,wpq864|\
+	linksys,e8350-v1|\
 	netgear,d7800 |\
 	netgear,r7500 |\
 	netgear,r7500v2 |\

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-e8350-v1.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-e8350-v1.dts
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+#include "qcom-ipq8064-v2.0.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/soc/qcom,tcsr.h>
+
+/ {
+	model = "Linksys E8350 V1 WiFi Router";
+	compatible = "linksys,e8350-v1", "qcom,ipq8064";
+
+	memory@0 {
+		reg = <0x42000000 0x1e000000>;
+		device_type = "memory";
+	};
+
+	aliases {
+		serial0 = &gsbi4_serial;
+
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
+
+		reset {
+			label = "reset";
+			gpios = <&qcom_pinmux 68 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+			wakeup-source;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&qcom_pinmux 65 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+			wakeup-source;
+		};
+
+		wifi {
+			label = "wifi";
+			gpios = <&qcom_pinmux 67 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+			debounce-interval = <60>;
+			wakeup-source;
+		};
+	};
+
+	nand-controller@1ac00000 {
+		compatible = "qcom,ipq806x-nand";
+		reg = <0x1ac00000 0x800>;
+		clocks = <&gcc EBI2_CLK>,
+			<&gcc EBI2_AON_CLK>;
+		clock-names = "core", "aon";
+		dmas = <&adm_dma 3>;
+		dma-names = "rxtx";
+		qcom,cmd-crci = <15>;
+		qcom,data-crci = <3>;
+
+		nand@0 {
+			reg = <0>;
+
+			nand-ecc-strength = <4>;
+			nand-bus-width = <8>;
+
+			partitions {
+				compatible = "fixed-partitions";
+
+				partition@0 {
+					label = "ubi";
+					reg = <0 0x4000000>;
+				};
+	
+				partition@4000000 {
+					label = "extra";
+					reg = <0x4000000 0x4000000>;
+				};
+			};
+		};
+	};
+
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-0 = <&led_pins>;
+		pinctrl-names = "default";
+
+		led_power: power {
+			label = "green:power";
+			gpios = <&qcom_pinmux 26 GPIO_ACTIVE_HIGH>;
+			default-state = "keep";
+		};
+
+		wps {
+			label = "green:wps";
+			gpios = <&qcom_pinmux 53 GPIO_ACTIVE_HIGH>;
+                };
+
+		wifi {
+			label = "green:wifi";
+			gpios = <&qcom_pinmux 54 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&qcom_pinmux {
+	button_pins: button_pins {
+		mux {
+			pins = "gpio68","gpio65", "gpio67";
+			function = "gpio";
+			drive-strength = <2>;
+			bias-pull-up;
+		};
+	};
+
+	led_pins: led_pins {
+		mux {
+			pins = "gpio26","gpio53", "gpio54";
+			function = "gpio";
+			drive-strength = <2>;
+			bias-pull-up;
+		};
+	};
+};
+
+&gsbi4 {
+	qcom,mode = <GSBI_PROT_I2C_UART>;
+	status = "okay";
+	serial@16340000 {
+		status = "okay";
+	};
+	/*
+	* The i2c device on gsbi4 should not be enabled.
+	* On ipq806x designs gsbi4 i2c is meant for exclusive
+	* RPM usage. Turning this on in kernel manifests as
+	* i2c failure for the RPM.
+	*/
+};
+&gsbi5 {
+	qcom,mode = <GSBI_PROT_SPI>;
+	status = "okay";
+
+	spi5: spi@1a280000 {
+		status = "okay";
+
+		pinctrl-0 = <&spi_pins>;
+		pinctrl-names = "default";
+
+		cs-gpios = <&qcom_pinmux 20 GPIO_ACTIVE_HIGH>;
+
+		m25p80@0 {
+			compatible = "jedec,spi-nor";
+			spi-max-frequency = <51200000>;
+			reg = <0>;
+
+			partitions {
+				compatible = "qcom,smem";
+			};
+		};
+	};
+};
+
+&sata_phy {
+	status = "okay";
+};
+
+&sata {
+	status = "okay";
+};
+
+&usb3_0 {
+	clocks = <&gcc USB30_1_MASTER_CLK>;
+	status = "okay";
+};
+
+&usb3_1 {
+	clocks = <&gcc USB30_0_MASTER_CLK>;
+	status = "okay";
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&pcie1 {
+	status = "okay";
+};
+
+&pcie2 {
+	status = "okay";
+};
+
+&mdio0 {
+	status = "okay";
+
+	pinctrl-0 = <&mdio0_pins>;
+	pinctrl-names = "default";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		qca,ar8327-initvals = <
+			0x00004 0x7600000   /* PAD0_MODE */
+			0x00008 0x1000000   /* PAD5_MODE */
+			0x0000c 0x80        /* PAD6_MODE */
+			0x00010 0x2613a0    /* PWS_REG */
+			0x000e4 0x6a545     /* MAC_POWER_SEL */
+			0x000e0 0xc74164de  /* SGMII_CTRL */
+			0x0007c 0x4e        /* PORT0_STATUS */
+			0x00094 0x4e        /* PORT6_STATUS */
+			>;
+	};
+};
+
+&gmac1 {
+	status = "okay";
+	phy-mode = "rgmii";
+	qcom,id = <1>;
+
+	pinctrl-0 = <&rgmii2_pins>;
+	pinctrl-names = "default";
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&gmac2 {
+	status = "okay";
+	phy-mode = "sgmii";
+	qcom,id = <2>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&tcsr {
+	qcom,usb-ctrl-select = <TCSR_USB_SELECT_USB3_DUAL>;
+	compatible = "qcom,tcsr";
+};
+
+&adm_dma {
+	status = "okay";
+};

--- a/target/linux/ipq806x/image/generic.mk
+++ b/target/linux/ipq806x/image/generic.mk
@@ -25,6 +25,16 @@ define Build/edimax-header
 	@mv $@.new $@
 endef
 
+define Build/linksys-bin
+		$(STAGING_DIR_HOST)/bin/addpattern -p $(FW_DEVICE_ID) -v $(FW_VERSION) $(if $(SERIAL),-s $(SERIAL)) -i $@ -o $@.new
+		mv $@.new $@
+endef
+# Use Linksys fw header generator to upgrade openwrt factory image over the native Linksys WEB interface
+define Build/linksys-addfwhdr
+		-$(STAGING_DIR_HOST)/bin/addfwhdr -i $@ -o $@.new \
+		;mv "$@.new" "$@"
+endef
+
 define Device/DniImage
 	KERNEL_SUFFIX := -uImage
 	KERNEL = kernel-bin | append-dtb | uImage none
@@ -144,6 +154,25 @@ define Device/edgecore_ecw5410
 	DEVICE_PACKAGES := ath10k-firmware-qca9984-ct
 endef
 TARGET_DEVICES += edgecore_ecw5410
+
+define Device/linksys_e8350-v1
+	$(call Device/LegacyImage)
+	DEVICE_VENDOR := Linksys
+	DEVICE_MODEL := E8350
+	DEVICE_VARIANT := v1
+	SOC := qcom-ipq8064
+	FW_VERSION := v1.0.03.003
+	FW_DEVICE_ID := 8350
+	PAGESIZE := 2048
+	BLOCKSIZE := 128k
+	KERNEL_IN_UBI := 1
+	IMAGES = factory.bin sysupgrade.ubi sysupgrade.bin
+	IMAGE/sysupgrade.ubi := append-ubi | check-size 0x04000000 | append-metadata
+	IMAGE/sysupgrade.bin = sysupgrade-tar | append-metadata
+	IMAGE/factory.bin := append-ubi | check-size 0x04000000 | linksys-addfwhdr | linksys-bin
+	DEVICE_PACKAGES := ath10k-firmware-qca988x-ct
+endef
+TARGET_DEVICES += linksys_e8350-v1
 
 define Device/linksys_ea7500-v1
 	$(call Device/LegacyImage)

--- a/target/linux/ipq806x/patches-5.10/0069-arm-boot-add-dts-files.patch
+++ b/target/linux/ipq806x/patches-5.10/0069-arm-boot-add-dts-files.patch
@@ -10,7 +10,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -909,8 +909,30 @@ dtb-$(CONFIG_ARCH_QCOM) += \
+@@ -909,8 +909,31 @@ dtb-$(CONFIG_ARCH_QCOM) += \
  	qcom-ipq4019-ap.dk04.1-c3.dtb \
  	qcom-ipq4019-ap.dk07.1-c1.dtb \
  	qcom-ipq4019-ap.dk07.1-c2.dtb \
@@ -21,6 +21,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	qcom-ipq8064-d7800.dtb \
 +	qcom-ipq8064-db149.dtb \
 +	qcom-ipq8064-ap161.dtb \
++	qcom-ipq8064-e8350-v1.dtb \
 +	qcom-ipq8064-ea7500-v1.dtb \
 +	qcom-ipq8064-ea8500.dtb \
 +	qcom-ipq8064-g10.dtb \

--- a/tools/firmware-utils/patches/999-add-hardware-header-generation-tool-linksys.patch
+++ b/tools/firmware-utils/patches/999-add-hardware-header-generation-tool-linksys.patch
@@ -1,0 +1,194 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f0f608a..24fc07b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -27,6 +27,7 @@ MACRO(FW_UTIL util deps extra_cflags libs)
+ ENDMACRO(FW_UTIL)
+ 
+ FW_UTIL(add_header "" "" "")
++FW_UTIL(addfwhdr src/cyg_crc32.c "" "")
+ FW_UTIL(addpattern "" "" "")
+ FW_UTIL(asustrx "" "" "")
+ FW_UTIL(avm-wasp-checksum "" --std=gnu99 "")
+diff --git a/src/addfwhdr.c b/src/addfwhdr.c
+new file mode 100644
+index 0000000..1b699c2
+--- /dev/null
++++ b/src/addfwhdr.c
+@@ -0,0 +1,176 @@
++/*
++	Linksys e8350 v1 firmware header generator
++*/
++#include <stdio.h>
++#include <string.h>
++#include <stdlib.h>
++#include <fcntl.h>
++#include <unistd.h>
++#include <sys/stat.h>
++#include <stdarg.h>
++#include <getopt.h>
++#include <time.h>
++#include <sys/time.h>
++
++#include "cyg_crc.h"
++
++//add for AC2350 F/W header
++#define FWHDR_MAGIC_STR "CHDR"
++#define FWHDR_MAGIC 0X52444843
++struct cbt_fw_header
++{
++	unsigned int magic;             /* "CHDR" */
++	unsigned int len;               /* Length of file including header */
++	unsigned int crc32;             /* 32-bit CRC */
++	unsigned int res;
++};
++
++#define MAX_BUF	1024
++#define CRC32_INIT_VALUE 0xffffffff	/* Initial CRC32 checksum value */
++
++#ifndef TYPEDEF_UINT8
++typedef unsigned char   uint8;
++#endif
++
++#ifndef TYPEDEF_UINT16
++typedef unsigned short  uint16;
++#endif
++
++#ifndef TYPEDEF_UINT32
++typedef unsigned int    uint32;
++#endif
++
++int fd, fd_w;
++
++void die(const char * str, ...)
++{
++	va_list args;
++	va_start(args, str);
++	vfprintf(stderr, str, args);
++	fputc('\n', stderr);
++	exit(1);
++}
++
++int fill_null0(int size)
++{
++	unsigned char buf[1];
++	int i;
++
++	fprintf(stderr,"Fill null\n");
++
++	buf[0] = 0xff;
++	for (i=0 ; i< size; i++ )
++		if (write(fd_w, buf, 1) != 1)
++			return 0;
++
++	return 1;
++}
++
++long file_open(const char *name)
++{
++	struct stat sb;
++	if ((fd = open(name, O_RDONLY, 0)) < 0){
++		die("Unable to open `%s' : %m", name);
++	}
++
++	if (fstat (fd, &sb))
++		die("Unable to stat `%s' : %m", name);
++
++	return sb.st_size;
++}
++
++void usage(void)
++{
++	die("Usage: addfwhdr [-i|--input] sysupgrade.o [-o|--output] code.bin\n");
++}
++
++int main(int argc, char ** argv)
++{
++	unsigned int input_size,c;
++	char *input_file=NULL, *output_file=NULL;
++	int opt;
++	int option_index=0;
++	char *buf = NULL;
++	extern char *optarg;
++	extern int optind, opterr, optopt;
++	
++	struct cbt_fw_header *fwhdr;
++	uint32 crc;	
++
++	static struct option long_options[] =
++	{
++		{"input", 1, 0, 'i'},
++		{"output", 1, 0, 'o'},
++		{0, 0, 0, 0}
++	};
++
++	printf("\n---------- add fw header --------\n");
++
++	fwhdr  = malloc(sizeof(struct cbt_fw_header));
++	memset(fwhdr, 0, sizeof(struct cbt_fw_header));	
++
++	while(1){
++		opt = getopt_long(argc, argv, "i:o:g",long_options, &option_index);
++		if(opt == -1)
++			break;
++		switch(opt){
++			case 'h' : 
++				usage(); break;
++			case 'i' :
++				input_file = optarg;
++				printf("input file is [%s]\n",input_file); break;
++			case 'o' :
++				output_file = optarg;
++				printf("output file is [%s]\n",output_file); break;
++			default :
++				usage();
++		}
++	}
++
++	if(!input_file || !output_file)
++	{
++		printf("You must specify the input and output file!\n");
++		usage();
++	}
++
++	
++	unlink(output_file);
++	if ((fd_w = open(output_file,O_RDWR|O_CREAT, S_IREAD | S_IWRITE)) < 0){
++		die("Unable to open `%s' : %m", output_file);
++	}
++	
++	fwhdr = malloc(sizeof(struct cbt_fw_header));
++	memset(fwhdr, 0, sizeof(struct cbt_fw_header));	
++	
++	memcpy((char *)&fwhdr->magic, FWHDR_MAGIC_STR, sizeof(fwhdr->magic));
++	
++	input_size = file_open(input_file);
++	if(!(buf = malloc(input_size)))
++	{
++		perror("malloc");
++		goto fail;
++	}
++	c = read(fd, buf, input_size);
++	fwhdr->len = input_size + sizeof(struct cbt_fw_header);
++
++	fwhdr->res = fwhdr->res | 0x1;
++	
++	crc = cyg_crc32_accumulate(CRC32_INIT_VALUE,(uint8_t *)&fwhdr->res, 4);
++	crc = cyg_crc32_accumulate(crc,(uint8_t *)&buf[0], input_size);
++	
++	fwhdr->crc32 = crc;
++
++	/* write code pattern header */
++	write(fd_w, fwhdr, sizeof(struct cbt_fw_header));
++
++	if(write(fd_w, buf, c)!=c)
++		die("Write call failed!\n");
++	
++fail:
++	if(buf)
++		free(buf);
++	close (fd);
++	close (fd_w);
++	
++	return 0;
++}


### PR DESCRIPTION
- add new "addfwhdr" tool to firmware tools. Needed to add support of sysupgrade from vendor firmware.
- add device dts and respective led/network/paltform
- add new dtb to boot patch

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
